### PR TITLE
Refactor image export to direct download and add privacy notice

### DIFF
--- a/v1.0.0.html
+++ b/v1.0.0.html
@@ -531,6 +531,7 @@
         <div class="widthWrapper">
             <button id="Edit"></button>
             <h1>Play List</h1>
+            <p>Your data privacy is important to us. This tool does not log or store any of your data, not even for analytics.</p>
             <div class="legend">
                 <div><span data-color="#FFFFFF" class="choice notEntered"></span> <span class="legend-text">Not Entered</span></div>
                 <div><span data-color="#FE6BB4" class="choice favorite"></span> <span class="legend-text">Favorite</span></div>
@@ -541,7 +542,7 @@
             </div>
             <div id="ExportWrapper">
                 <input type="text" id="URL">
-                <button id="Export">Export</button>
+                <button id="Export">Download Image</button>
                 <div id="Loading">Loading</div>
             </div>
             <button id="StartBtn"></button>
@@ -1063,30 +1064,14 @@
                         
                         //return $(canvas).insertBefore($('#InputList'));
                         
-                        // Send canvas to imgur
-                        $.ajax({
-                            url: 'https://api.imgur.com/3/image',
-                            type: 'POST',
-                            headers: {
-                                // Your application gets an imgurClientId from Imgur
-                                Authorization: 'Client-ID ' + imgurClientId,
-                                Accept: 'application/json'
-                            },
-                            data: {
-                                // convert the image data to base64
-                                image:  canvas.toDataURL().split(',')[1],
-                                type: 'base64'
-                            },
-                            success: function(result) {
-                                $('#Loading').hide();
-                                var url = 'https://i.imgur.com/' + result.data.id + '.png';
-                                $('#URL').val(url).fadeIn();
-                            },
-                            fail: function(){
-                                $('#Loading').hide();
-                                alert('Failed to upload to imgur, could not connect');
-                            }
-                        });
+                        // Trigger download of the canvas image
+                        var link = document.createElement('a');
+                        link.download = 'playlist.png';
+                        link.href = canvas.toDataURL('image/png').replace('image/png', 'image/octet-stream');
+                        link.click();
+
+                        $('#Loading').hide();
+                        $('#URL').fadeOut();
                     },
                     encode: function(base, input){
                         var hashBase = inputKinks.hashChars.length;


### PR DESCRIPTION
Changes:
- Modified the image export functionality to remove the Imgur API integration.
- Implemented direct client-side download of the generated image as a PNG file named 'playlist.png'.
- Updated the export button text from "Export" to "Download Image" for clarity.
- Added a data privacy notice at the top of the page, informing you that no data is logged or stored.